### PR TITLE
Parameterize macOS signing identity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 APPLE_ID=your.apple.id@example.com
 APPLE_ID_PASSWORD=app-specific-password-from-apple-account
 APPLE_TEAM_ID=your-team-id-if-you-have-multiple-teams
+APPLE_DEVELOPER_IDENTITY=Your Name (YOUR_TEAM_ID)
 
 # Set to 'true' to skip notarization (for development builds)
 SKIP_NOTARIZATION=false

--- a/README.md
+++ b/README.md
@@ -99,11 +99,14 @@ For developers distributing macOS applications:
    APPLE_ID=your.apple.id@example.com
    APPLE_ID_PASSWORD=app-specific-password-from-apple-account
    APPLE_TEAM_ID=your-team-id-if-you-have-multiple-teams
+   APPLE_DEVELOPER_IDENTITY=Your Name (YOUR_TEAM_ID)
    ```
 
 2. For the `APPLE_ID_PASSWORD`, create an app-specific password at https://appleid.apple.com/account/manage
 
-3. Build the application:
+3. The `APPLE_DEVELOPER_IDENTITY` should be in the format "Your Name (YOUR_TEAM_ID)" and matches the identity shown when running `security find-identity -v -p codesigning` in Terminal
+
+4. Build the application:
    ```
    npm run dist-mac
    ```

--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
     "start-prod": "NODE_ENV=production electron .",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",
-    "dist-mac": "electron-builder --mac",
-    "dist-mac-alpha": "SKIP_NOTARIZATION=true electron-builder --mac --config.mac.notarize=false",
+    "dist-mac": "electron-builder --mac --config.mac.identity=\"$APPLE_DEVELOPER_IDENTITY\"",
+    "dist-mac-alpha": "SKIP_NOTARIZATION=true electron-builder --mac --config.mac.notarize=false --config.mac.identity=null",
     "dist-win": "electron-builder --win",
     "dist-linux": "electron-builder --linux",
     "dist-all": "electron-builder -mwl"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Dorky-Robot/lahat"
+    "url": "https://github.com/NerdNest-Engineering/lahat"
   },
   "keywords": [
     "electron",
@@ -29,14 +29,14 @@
     "lahat"
   ],
   "author": {
-    "name": "Dorky Robot",
-    "email": "contact@dorkyrobot.com"
+    "name": "NerdNest LLC",
+    "email": "support@nerdnest.engineering"
   },
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/Dorky-Robot/lahat/issues"
+    "url": "https://github.com/NerdNest-Engineering/lahat/issues"
   },
-  "homepage": "https://github.com/Dorky-Robot/lahat",
+  "homepage": "https://nerdnest-engineering.github.io/lahat/",
   "devDependencies": {
     "@electron/notarize": "^2.5.0",
     "dotenv": "^16.4.7",
@@ -63,7 +63,7 @@
         "zip"
       ],
       "darkModeSupport": true,
-      "notarize": true,
+      "notarize": false,
       "artifactName": "${productName}-${version}.${ext}"
     },
     "afterSign": "scripts/notarize.js",
@@ -85,7 +85,7 @@
     },
     "publish": {
       "provider": "github",
-      "owner": "Dorky-Robot",
+      "owner": "NerdNest-Engineering",
       "repo": "lahat"
     },
     "asar": true,

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -13,8 +13,13 @@ import fs from 'fs';
 import path from 'path';
 import dotenv from 'dotenv'; // For loading environment variables from .env file
 
-// Load environment variables
-dotenv.config();
+// Load environment variables with explicit path
+const result = dotenv.config();
+if (result.error) {
+  console.warn('Error loading .env file:', result.error.message);
+} else {
+  console.log('.env file loaded successfully');
+}
 
 export default async function (params) {
   // Skip notarization during development or if explicitly disabled


### PR DESCRIPTION
- Remove hardcoded identity from package.json
- Use APPLE_DEVELOPER_IDENTITY environment variable for signing
- Update README.md with documentation for the new variable
- Enhance scripts/notarize.js with better debugging
- Update .env.example with the new environment variable
- Ensure alpha builds explicitly skip signing

Test dist-mac-alpha
```
➜  npm run dist-mac-alpha

> lahat@1.0.11 dist-mac-alpha
> SKIP_NOTARIZATION=true electron-builder --mac --config.mac.notarize=false --config.mac.identity=null

  • electron-builder  version=25.1.8 os=24.1.0
  • loaded configuration  file=package.json ("build" field)
  • writing effective config  file=dist/builder-effective-config.yaml
  • executing @electron/rebuild  electronVersion=34.3.0 arch=arm64 buildFromSource=false appDir=./
  • installing native dependencies  arch=arm64
  • completed installing native dependencies
  • packaging       platform=darwin arch=arm64 electron=34.3.0 appOutDir=dist/mac-arm64
  • skipped macOS code signing  reason=identity explicitly is set to null
.env file loaded successfully
Skipping notarization
  • building        target=DMG arch=arm64 file=dist/Lahat-1.0.11.dmg
  • building        target=macOS zip arch=arm64 file=dist/Lahat-1.0.11.zip
  • Detected arm64 process, HFS+ is unavailable. Creating dmg with APFS - supports Mac OSX 10.12+
  • building block map  blockMapFile=dist/Lahat-1.0.11.dmg.blockmap
  • building block map  blockMapFile=dist/Lahat-1.0.11.zip.blockmap
```

Test dist-mac-alpha
```
➜  npm run dist-mac      

> lahat@1.0.11 dist-mac
> electron-builder --mac --config.mac.identity="$APPLE_DEVELOPER_IDENTITY"

  • electron-builder  version=25.1.8 os=24.1.0
  • loaded configuration  file=package.json ("build" field)
  • writing effective config  file=dist/builder-effective-config.yaml
  • executing @electron/rebuild  electronVersion=34.3.0 arch=arm64 buildFromSource=false appDir=./
  • installing native dependencies  arch=arm64
  • completed installing native dependencies
  • packaging       platform=darwin arch=arm64 electron=34.3.0 appOutDir=dist/mac-arm64
  • signing         file=dist/mac-arm64/Lahat.app platform=darwin type=distribution identity=E7FF9FD9634CD1ABB97EE253F6B3EB44E1CEFF43 provisioningProfile=none
  • skipped macOS notarization  reason=`notarize` options were set explicitly `false`
.env file loaded successfully
Notarizing Lahat at /***/Lahat.app
Successfully notarized Lahat
  • building        target=DMG arch=arm64 file=dist/Lahat-1.0.11.dmg
  • building        target=macOS zip arch=arm64 file=dist/Lahat-1.0.11.zip
  • Detected arm64 process, HFS+ is unavailable. Creating dmg with APFS - supports Mac OSX 10.12+
  • building block map  blockMapFile=dist/Lahat-1.0.11.dmg.blockmap
  • building block map  blockMapFile=dist/Lahat-1.0.11.zip.blockmap
  ```