### PR TITLE
feat: Add dark mode toggle to main UI

### DIFF
--- a/context_sheets/changes/20250420-dark-mode-implementation-plan.md
+++ b/context_sheets/changes/20250420-dark-mode-implementation-plan.md
@@ -1,0 +1,408 @@
+# Dark Mode Implementation Plan
+
+<!-- SUMMARY -->
+This document outlines the implementation plan for adding a dark mode feature to the Lahat application. The feature will include a simple toggle between light and dark modes in the app-controls-header area, and changes will apply immediately without requiring a restart. The implementation will focus on simplicity by only including a manual toggle without system theme integration for now.
+<!-- /SUMMARY -->
+
+<!-- RELATED DOCUMENTS -->
+related '../architecture/technical_architecture.md'
+related '../architecture/window_sheets_architecture.md'
+related '../user_experience/user_experience.md'
+<!-- /RELATED DOCUMENTS -->
+
+## Overview
+
+The dark mode implementation will provide users with the ability to switch between light and dark themes in the Lahat application. The existing ThemeManager class already has core functionality but needs UI integration and CSS updates. The implementation will focus on:
+
+1. Updating CSS variables to support both light and dark themes
+2. Adding a simple theme toggle in the app-controls-header
+3. Connecting the UI to the ThemeManager
+4. Ensuring immediate application of theme changes
+
+This implementation will be kept simple by focusing only on a manual toggle without the system theme following option for now.
+
+```mermaid
+graph TD
+    A[Update CSS Variables] --> B[Implement UI Toggle]
+    B --> C[Connect Toggle to ThemeManager]
+    C --> D[Update IPC Communication]
+    D --> E[Test & Refine]
+```
+
+## 1. CSS Structure Updates
+
+The current CSS uses variables for colors but needs dark theme variants:
+
+```mermaid
+graph TD
+    A[Current CSS] --> B[Add Dark Theme Variables]
+    B --> C[Update Element Styles]
+    C --> D[Add Theme-Specific Styles]
+```
+
+### CSS Modifications
+
+We'll modify `styles.css` to include dark theme variables:
+
+```css
+:root {
+  /* Common variables */
+  --border-radius: 8px;
+  --shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  --drag-region-height: 38px;
+  
+  /* Light theme colors (default) */
+  --primary-color: #4285f4;
+  --primary-dark: #3367d6;
+  --secondary-color: #34a853;
+  --danger-color: #ea4335;
+  --warning-color: #fbbc05;
+  --light-gray: #f8f9fa;
+  --medium-gray: #e0e0e0;
+  --dark-gray: #5f6368;
+  
+  /* Background and text colors */
+  --bg-color: #ffffff;
+  --text-color: #202124;
+  --card-bg-color: var(--light-gray);
+  --modal-bg-color: white;
+  --border-color: var(--medium-gray);
+}
+
+[data-theme="dark"] {
+  /* Dark theme colors */
+  --primary-color: #7baaf7;
+  --primary-dark: #5c8df1;
+  --secondary-color: #4cc669;
+  --danger-color: #f16c6c;
+  --warning-color: #fcd053;
+  --light-gray: #2c2c2c;
+  --medium-gray: #3e3e3e;
+  --dark-gray: #b0b0b0;
+  
+  /* Background and text colors */
+  --bg-color: #1e1e1e;
+  --text-color: #e8eaed;
+  --card-bg-color: #2d2d2d;
+  --modal-bg-color: #2d2d2d;
+  --border-color: #3e3e3e;
+}
+```
+
+Update core element styles to use these variables:
+
+```css
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  background: var(--bg-color);
+  color: var(--text-color);
+}
+
+.window {
+  max-width: 1200px;
+  margin: 0 auto;
+  background: var(--bg-color);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.section {
+  background: var(--bg-color);
+  border-radius: var(--border-radius);
+  padding: 20px;
+  box-shadow: var(--shadow);
+}
+
+.modal-content {
+  background: var(--modal-bg-color);
+  border-radius: var(--border-radius);
+}
+```
+
+## 2. UI Toggle Component
+
+We'll add a theme toggle to the app-controls-header:
+
+```mermaid
+graph TD
+    A[Design Toggle Component] --> B[Add to app-controls-header]
+    B --> C[Style Toggle Component]
+    C --> D[Add Event Listeners]
+```
+
+### HTML Changes
+
+In `main.html`, we'll add the toggle to the app-controls-header:
+
+```html
+<div class="app-controls-header">
+  <h2>Lahat <span class="tagalog-text">ᜎᜑᜆ᜔</span></h2>
+  <div class="app-controls">
+    <!-- New theme toggle -->
+    <div class="theme-toggle">
+      <label class="toggle-switch">
+        <input type="checkbox" id="theme-toggle">
+        <span class="toggle-slider"></span>
+      </label>
+      <span id="theme-label">Light</span>
+    </div>
+    <!-- Existing buttons -->
+    <button id="api-settings-button" class="secondary">API Settings</button>
+    <button id="create-app-button" class="primary">Create New App</button>
+    <!-- Other buttons -->
+  </div>
+</div>
+```
+
+### CSS for the Toggle
+
+We'll add the following CSS to `styles.css` or `styles/main.css`:
+
+```css
+/* Theme Toggle */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  margin-right: 10px;
+}
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+  margin: 0 8px;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--medium-gray);
+  transition: .4s;
+  border-radius: 20px;
+}
+
+.toggle-slider:before {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  left: 2px;
+  bottom: 2px;
+  background-color: white;
+  transition: .4s;
+  border-radius: 50%;
+}
+
+input:checked + .toggle-slider {
+  background-color: var(--primary-color);
+}
+
+input:checked + .toggle-slider:before {
+  transform: translateX(20px);
+}
+```
+
+## 3. IPC Communication Updates
+
+We need to update the IPC communication to handle theme changes:
+
+```mermaid
+graph TD
+    A[Extend IPC Types] --> B[Update Main Process Handlers]
+    B --> C[Implement Renderer Handlers]
+    C --> D[Connect to UI Toggle]
+```
+
+### IPC Types Update
+
+In `modules/ipc/ipcTypes.js`, add theme-related channels:
+
+```javascript
+export const IpcChannels = {
+  // Existing channels...
+  
+  // Theme related
+  GET_THEME_SETTINGS: 'get-theme-settings',
+  SET_THEME: 'set-theme',
+  THEME_CHANGED: 'theme-changed',
+};
+```
+
+### Main Process Handlers
+
+Add handlers to `modules/ipc/windowHandlers.js` or create a new file `modules/ipc/themeHandlers.js`:
+
+```javascript
+import themeManager from '../utils/themeManager.js';
+import { ipcMain } from 'electron';
+
+// Handle getting theme settings
+async function handleGetThemeSettings() {
+  return themeManager.getThemeSettings();
+}
+
+// Handle setting theme
+async function handleSetTheme(event, { theme }) {
+  themeManager.setTheme(theme);
+  return { success: true };
+}
+
+// Register theme-related IPC handlers
+export function registerThemeHandlers() {
+  ipcMain.handle('get-theme-settings', handleGetThemeSettings);
+  ipcMain.handle('set-theme', handleSetTheme);
+}
+```
+
+### Preload Script Updates
+
+Update `preload.cjs` to expose the new IPC methods:
+
+```javascript
+// Theme API
+contextBridge.exposeInMainWorld('electronAPI', {
+  // Existing API...
+  
+  // Theme API
+  getThemeSettings: () => ipcRenderer.invoke('get-theme-settings'),
+  setTheme: (theme) => ipcRenderer.invoke('set-theme', theme),
+  onThemeChanged: (callback) => ipcRenderer.on('theme-changed', (event, settings) => callback(settings)),
+});
+```
+
+## 4. Renderer Integration
+
+Update `renderers/main.js` to handle theme toggling:
+
+```mermaid
+graph TD
+    A[Initialize Theme UI] --> B[Add Event Listeners]
+    B --> C[Handle Theme Changes]
+    C --> D[Update UI on Theme Change]
+```
+
+### Theme Initialization
+
+Add to `renderers/main.js`:
+
+```javascript
+// Theme initialization
+async function initializeTheme() {
+  // Get current theme settings
+  const themeSettings = await window.electronAPI.getThemeSettings();
+  
+  // Set initial UI state
+  const themeToggle = document.getElementById('theme-toggle');
+  const themeLabel = document.getElementById('theme-label');
+  
+  // Update toggle based on current theme
+  themeToggle.checked = themeSettings.theme === 'dark';
+  themeLabel.textContent = themeSettings.theme === 'dark' ? 'Dark' : 'Light';
+  
+  // Set up event listener for toggle
+  themeToggle.addEventListener('change', async () => {
+    const newTheme = themeToggle.checked ? 'dark' : 'light';
+    themeLabel.textContent = newTheme === 'dark' ? 'Dark' : 'Light';
+    await window.electronAPI.setTheme({ theme: newTheme });
+  });
+  
+  // Listen for theme changes from main process
+  window.electronAPI.onThemeChanged((settings) => {
+    // Update UI when theme changes externally
+    themeToggle.checked = settings.currentTheme === 'dark';
+    themeLabel.textContent = settings.currentTheme === 'dark' ? 'Dark' : 'Light';
+  });
+}
+
+// Add to initialization
+function initializeApp() {
+  // Existing initialization code...
+  
+  // Initialize theme
+  initializeTheme();
+}
+```
+
+## 5. Main Process Initialization
+
+Update `main.js` to initialize the theme manager:
+
+```javascript
+// Initialize theme manager
+import themeManager from './modules/utils/themeManager.js';
+import { registerThemeHandlers } from './modules/ipc/themeHandlers.js';
+
+// In app ready handler
+app.whenReady().then(() => {
+  // Initialize theme manager
+  themeManager.initialize();
+  
+  // Register theme IPC handlers
+  registerThemeHandlers();
+  
+  // Existing initialization code...
+});
+```
+
+## 6. Testing and Refinements
+
+Testing plan to ensure proper implementation:
+
+1. Test theme toggle functionality:
+   - Toggle between light and dark modes
+   - Verify visual changes apply immediately
+   - Check toggle state reflects current theme
+
+2. Verify theme persistence:
+   - Change theme, restart application
+   - Confirm theme setting is preserved
+
+3. Test UI components in both themes:
+   - Check all UI elements for proper styling
+   - Ensure proper contrast and readability
+   - Verify text remains legible in both themes
+   - Test modals and popups
+
+4. Test multi-window behavior:
+   - Verify theme changes apply to all application windows
+   - Confirm theme toggle state is consistent across windows
+   - Confirm mini apps remain unaffected as specified
+
+## 7. Implementation Timeline
+
+1. CSS Updates - 1 day
+   - Update variables
+   - Modify element styles
+
+2. UI Toggle Component - 1 day
+   - Add HTML for toggle
+   - Style the component
+
+3. IPC and Renderer Integration - 1 day
+   - Update IPC handlers
+   - Implement renderer logic
+
+4. Testing and Refinements - 1 day
+   - Test functionality
+   - Make visual adjustments
+
+Total estimated time: 4 days
+
+## Conclusion
+
+This implementation plan provides a simple yet effective approach to adding dark mode support to the Lahat application. The implementation builds on the existing ThemeManager class, extends the CSS variable system, and adds a user-friendly toggle in the app-controls-header area.
+
+By focusing on just the manual toggle feature without system theme integration, we can deliver a clean, straightforward dark mode implementation that can be extended in the future if needed. The changes are designed to be minimal while providing a complete dark mode experience for users.

--- a/docs/daisyui-migration-plan.md
+++ b/docs/daisyui-migration-plan.md
@@ -1,0 +1,664 @@
+# Lahat UI Modernization: DaisyUI v5 Migration Plan
+
+## Overview
+
+This document outlines the comprehensive migration plan to transform Lahat from its current basic UI to a modern, sleek interface using DaisyUI v5 while maintaining future-proofing through a custom component wrapper system.
+
+## Project Goals
+
+- **Modernize UI**: Transform from basic styling to professional, modern interface
+- **Future-Proof Architecture**: Create Lahat wrapper components to avoid vendor lock-in
+- **System Integration**: Automatic theme matching with macOS/Windows/Linux system preferences
+- **Maintain Functionality**: Preserve all existing features during migration
+- **Performance**: Ensure no degradation in app performance
+
+## Architecture Strategy
+
+### Component Abstraction Layer
+```
+┌─────────────────────────────────────┐
+│           Lahat Components          │  ← Our API (never changes)
+│  <lahat-button>, <lahat-card>, etc. │
+├─────────────────────────────────────┤
+│           DaisyUI v5                │  ← Implementation (swappable)
+│     Tailwind CSS 4 + Components     │
+├─────────────────────────────────────┤
+│          Browser/Electron           │
+└─────────────────────────────────────┘
+```
+
+### Theme System Architecture
+```
+┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
+│  System Theme   │───▶│ Lahat Theme      │───▶│   DaisyUI       │
+│  (OS Preference)│    │ Controller       │    │   Themes        │
+└─────────────────┘    └──────────────────┘    └─────────────────┘
+                              │
+                              ▼
+                       ┌──────────────────┐
+                       │ User Preference  │
+                       │ (localStorage)   │
+                       └──────────────────┘
+```
+
+## Phase Breakdown
+
+### Phase 0: Foundation & Planning (Week 1)
+**Goal**: Establish the foundation for the migration
+
+#### 0.1 Design System Specification
+- [ ] Define Lahat component API specifications
+- [ ] Create component interface documentation
+- [ ] Establish naming conventions and patterns
+- [ ] Design theme system architecture
+
+#### 0.2 Development Environment Setup
+- [ ] Install Tailwind CSS 4
+- [ ] Install DaisyUI v5
+- [ ] Configure build system for CSS processing
+- [ ] Set up development tooling
+
+**Deliverables**:
+- Component API specification document
+- Development environment ready
+- Build system configured
+
+---
+
+### Phase 1: Core Infrastructure (Week 2)
+**Goal**: Build the Lahat Design System foundation
+
+#### 1.1 Base Component System
+Create the core wrapper components:
+
+```javascript
+// components/design-system/base/lahat-component.js
+export class LahatComponent extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+  
+  // Common functionality for all Lahat components
+  applyTheme(theme) { /* ... */ }
+  handleSystemThemeChange() { /* ... */ }
+}
+```
+
+#### 1.2 Theme Controller Implementation
+```javascript
+// components/design-system/lahat-theme-controller.js
+export class LahatThemeController extends LahatComponent {
+  constructor() {
+    super();
+    this.systemTheme = this.detectSystemTheme();
+    this.userTheme = localStorage.getItem('lahat-theme');
+    this.setupSystemThemeListener();
+  }
+  
+  detectSystemTheme() {
+    // Electron nativeTheme integration
+    // CSS prefers-color-scheme fallback
+  }
+}
+```
+
+#### 1.3 Core Components
+- [ ] `<lahat-button>` - Button wrapper
+- [ ] `<lahat-card>` - Card wrapper  
+- [ ] `<lahat-input>` - Input wrapper
+- [ ] `<lahat-modal>` - Modal wrapper
+- [ ] `<lahat-navbar>` - Navigation wrapper
+
+**DaisyUI v5 Integration Pattern**:
+```javascript
+// Example: lahat-button.js
+export class LahatButton extends LahatComponent {
+  render() {
+    return `
+      <button class="btn ${this.variant} ${this.size}">
+        <slot></slot>
+      </button>
+    `;
+  }
+  
+  get variant() {
+    const variants = {
+      primary: 'btn-primary',
+      secondary: 'btn-secondary',
+      ghost: 'btn-ghost'
+    };
+    return variants[this.getAttribute('variant')] || 'btn-primary';
+  }
+}
+```
+
+**Deliverables**:
+- Core Lahat component system
+- Theme controller with system detection
+- Basic wrapper components
+
+---
+
+### Phase 2: DaisyUI v5 Integration (Week 3)
+**Goal**: Implement DaisyUI v5 as the backing system
+
+#### 2.1 DaisyUI v5 Configuration
+```css
+/* styles/daisyui-config.css */
+@import "tailwindcss";
+@plugin "daisyui" {
+  themes: light --default, dark --prefersdark, cupcake, cyberpunk, synthwave;
+  root: ":root";
+  prefix: "lahat-";
+  logs: false;
+}
+```
+
+#### 2.2 System Theme Integration
+```javascript
+// Electron main process integration
+const { nativeTheme } = require('electron');
+
+nativeTheme.on('updated', () => {
+  // Send theme change to renderer
+  mainWindow.webContents.send('system-theme-changed', {
+    shouldUseDarkColors: nativeTheme.shouldUseDarkColors,
+    themeSource: nativeTheme.themeSource
+  });
+});
+```
+
+#### 2.3 Component Implementation
+Update each wrapper component to use DaisyUI v5 classes:
+
+```javascript
+// lahat-button.js - Updated with DaisyUI v5
+export class LahatButton extends LahatComponent {
+  static get observedAttributes() {
+    return ['variant', 'size', 'loading', 'disabled'];
+  }
+  
+  render() {
+    const classes = [
+      'lahat-btn', // Our prefix
+      this.getVariantClass(),
+      this.getSizeClass(),
+      this.loading ? 'lahat-btn-loading' : '',
+      this.disabled ? 'lahat-btn-disabled' : ''
+    ].filter(Boolean).join(' ');
+    
+    return `
+      <style>
+        :host {
+          display: inline-block;
+        }
+        .lahat-btn {
+          @apply btn; /* DaisyUI v5 base class */
+        }
+        .lahat-btn-primary { @apply btn-primary; }
+        .lahat-btn-secondary { @apply btn-secondary; }
+        /* ... other variants */
+      </style>
+      <button class="${classes}" ?disabled="${this.disabled}">
+        ${this.loading ? '<span class="loading loading-spinner"></span>' : ''}
+        <slot></slot>
+      </button>
+    `;
+  }
+}
+```
+
+**Deliverables**:
+- DaisyUI v5 fully integrated
+- All wrapper components using DaisyUI classes
+- System theme detection working
+
+---
+
+### Phase 3: UI Component Migration (Week 4-5)
+**Goal**: Migrate existing UI to use Lahat components
+
+#### 3.1 Header/Navigation Migration
+**Before** (current):
+```html
+<div class="app-controls-header">
+  <h2>Lahat <span class="tagalog-text">ᜎᜑᜆ᜔</span></h2>
+  <div class="app-controls">
+    <button id="api-settings-button" class="secondary">API Settings</button>
+    <button id="create-app-button" class="primary">Create New App</button>
+    <!-- ... -->
+  </div>
+</div>
+```
+
+**After** (with Lahat components):
+```html
+<lahat-navbar>
+  <lahat-navbar-brand>
+    <lahat-text variant="heading">Lahat <span class="tagalog-text">ᜎᜑᜆ᜔</span></lahat-text>
+  </lahat-navbar-brand>
+  
+  <lahat-navbar-end>
+    <lahat-search placeholder="Search apps..."></lahat-search>
+    <lahat-theme-controller></lahat-theme-controller>
+    
+    <lahat-button-group>
+      <lahat-button variant="ghost" id="api-settings-button">API Settings</lahat-button>
+      <lahat-button variant="primary" id="create-app-button">Create New App</lahat-button>
+      <lahat-button variant="secondary" id="import-app-button">Import App</lahat-button>
+      <lahat-button variant="ghost" id="refresh-apps-button">Refresh</lahat-button>
+      <lahat-button variant="ghost" id="open-app-directory-button">Open Directory</lahat-button>
+    </lahat-button-group>
+  </lahat-navbar-end>
+</lahat-navbar>
+```
+
+#### 3.2 App Card Migration
+**Before**:
+```javascript
+// In app-card.js
+_getStyles() {
+  return `
+    .app-card {
+      background: var(--light-gray);
+      border-radius: var(--border-radius);
+      padding: 15px;
+      cursor: pointer;
+      transition: transform 0.2s, box-shadow 0.2s;
+    }
+    /* ... */
+  `;
+}
+```
+
+**After**:
+```javascript
+// Updated app-card.js
+_getTemplate() {
+  return `
+    <lahat-card hoverable clickable>
+      <lahat-card-body>
+        <lahat-card-title>${this.appData.name}</lahat-card-title>
+        <lahat-text variant="description">${this.appData.description}</lahat-text>
+        <lahat-card-actions>
+          <lahat-button variant="primary" size="sm">Open</lahat-button>
+          <lahat-button variant="ghost" size="sm">Delete</lahat-button>
+        </lahat-card-actions>
+      </lahat-card-body>
+    </lahat-card>
+  `;
+}
+```
+
+#### 3.3 Modal System Migration
+```javascript
+// New lahat-modal.js
+export class LahatModal extends LahatComponent {
+  render() {
+    return `
+      <style>
+        .lahat-modal { @apply modal; }
+        .lahat-modal-box { @apply modal-box; }
+        .lahat-modal-backdrop { @apply modal-backdrop; }
+      </style>
+      
+      <div class="lahat-modal ${this.open ? 'modal-open' : ''}">
+        <div class="lahat-modal-box">
+          <lahat-modal-header>
+            <slot name="header"></slot>
+            <lahat-button variant="ghost" size="sm" class="modal-close">✕</lahat-button>
+          </lahat-modal-header>
+          
+          <lahat-modal-body>
+            <slot></slot>
+          </lahat-modal-body>
+          
+          <lahat-modal-actions>
+            <slot name="actions"></slot>
+          </lahat-modal-actions>
+        </div>
+        <div class="lahat-modal-backdrop"></div>
+      </div>
+    `;
+  }
+}
+```
+
+**Deliverables**:
+- All major UI components migrated
+- Consistent design language throughout app
+- Improved accessibility and interactions
+
+---
+
+### Phase 4: Advanced Features & Polish (Week 6)
+**Goal**: Add advanced features and polish the experience
+
+#### 4.1 Enhanced Theme System
+```javascript
+// Advanced theme controller with multiple themes
+export class LahatThemeController extends LahatComponent {
+  constructor() {
+    super();
+    this.availableThemes = [
+      { name: 'light', label: 'Light', icon: '☀️' },
+      { name: 'dark', label: 'Dark', icon: '🌙' },
+      { name: 'cyberpunk', label: 'Cyberpunk', icon: '🤖' },
+      { name: 'synthwave', label: 'Synthwave', icon: '🌆' },
+      { name: 'cupcake', label: 'Cupcake', icon: '🧁' }
+    ];
+  }
+  
+  render() {
+    return `
+      <lahat-dropdown>
+        <lahat-button variant="ghost" slot="trigger">
+          <span class="theme-icon">${this.getCurrentThemeIcon()}</span>
+          Theme
+        </lahat-button>
+        
+        <lahat-dropdown-content>
+          ${this.availableThemes.map(theme => `
+            <lahat-dropdown-item 
+              value="${theme.name}"
+              ?selected="${this.currentTheme === theme.name}">
+              ${theme.icon} ${theme.label}
+            </lahat-dropdown-item>
+          `).join('')}
+        </lahat-dropdown-content>
+      </lahat-dropdown>
+    `;
+  }
+}
+```
+
+#### 4.2 Loading States & Micro-interactions
+```javascript
+// Enhanced loading states
+export class LahatButton extends LahatComponent {
+  async handleClick() {
+    if (this.loading) return;
+    
+    this.loading = true;
+    this.render();
+    
+    try {
+      await this.action();
+    } finally {
+      this.loading = false;
+      this.render();
+    }
+  }
+  
+  render() {
+    return `
+      <button class="lahat-btn ${this.getClasses()}" 
+              ?disabled="${this.disabled || this.loading}">
+        ${this.loading ? `
+          <lahat-loading-spinner size="sm"></lahat-loading-spinner>
+        ` : ''}
+        <slot></slot>
+      </button>
+    `;
+  }
+}
+```
+
+#### 4.3 Accessibility Enhancements
+- ARIA labels and descriptions
+- Keyboard navigation
+- Screen reader support
+- High contrast mode support
+- Reduced motion preferences
+
+#### 4.4 Performance Optimizations
+- Component lazy loading
+- CSS-in-JS optimization
+- Bundle size analysis
+- Memory leak prevention
+
+**Deliverables**:
+- Advanced theme system with multiple options
+- Smooth animations and micro-interactions
+- Full accessibility compliance
+- Performance optimizations
+
+---
+
+### Phase 5: Testing & Refinement (Week 7)
+**Goal**: Ensure quality and stability
+
+#### 5.1 Component Testing
+```javascript
+// Example test for lahat-button
+describe('LahatButton', () => {
+  it('should render with correct DaisyUI classes', () => {
+    const button = document.createElement('lahat-button');
+    button.setAttribute('variant', 'primary');
+    document.body.appendChild(button);
+    
+    expect(button.shadowRoot.querySelector('button')).toHaveClass('btn-primary');
+  });
+  
+  it('should handle loading state', async () => {
+    const button = document.createElement('lahat-button');
+    button.loading = true;
+    
+    expect(button.shadowRoot.querySelector('.loading')).toBeInTheDocument();
+  });
+});
+```
+
+#### 5.2 Integration Testing
+- Theme switching functionality
+- System theme detection
+- Component interactions
+- Electron integration
+
+#### 5.3 Performance Testing
+- Bundle size analysis
+- Runtime performance
+- Memory usage
+- Startup time
+
+**Deliverables**:
+- Comprehensive test suite
+- Performance benchmarks
+- Bug fixes and optimizations
+
+---
+
+## Implementation Details
+
+### DaisyUI v5 Specific Patterns
+
+#### Configuration
+```css
+/* Recommended DaisyUI v5 setup */
+@import "tailwindcss";
+@plugin "daisyui" {
+  themes: light --default, dark --prefersdark, cupcake, cyberpunk, synthwave, retro, valentine, halloween, garden, forest, aqua, lofi, pastel, fantasy, wireframe, black, luxury, dracula, cmyk, autumn, business, acid, lemonade, night, coffee, winter, dim, nord, sunset;
+  root: ":root";
+  include: ; /* Include all components */
+  exclude: ; /* Exclude none */
+  prefix: "lahat-"; /* Prefix for our components */
+  logs: false; /* Disable logs in production */
+}
+```
+
+#### Theme Controller Pattern
+```javascript
+// DaisyUI v5 theme controller integration
+export class LahatThemeController extends LahatComponent {
+  applyTheme(themeName) {
+    // DaisyUI v5 method
+    document.documentElement.setAttribute('data-theme', themeName);
+    
+    // Persist user choice
+    localStorage.setItem('lahat-theme', themeName);
+    
+    // Emit theme change event
+    this.dispatchEvent(new CustomEvent('theme-changed', {
+      detail: { theme: themeName },
+      bubbles: true
+    }));
+  }
+  
+  initializeTheme() {
+    // Priority: User preference > System preference > Default
+    const userTheme = localStorage.getItem('lahat-theme');
+    const systemTheme = this.getSystemTheme();
+    const defaultTheme = 'light';
+    
+    const theme = userTheme || systemTheme || defaultTheme;
+    this.applyTheme(theme);
+  }
+  
+  getSystemTheme() {
+    // Electron integration
+    if (window.electronAPI) {
+      return window.electronAPI.getSystemTheme();
+    }
+    
+    // Fallback to CSS media query
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+}
+```
+
+### Component API Specifications
+
+#### LahatButton
+```typescript
+interface LahatButtonProps {
+  variant?: 'primary' | 'secondary' | 'accent' | 'ghost' | 'link' | 'info' | 'success' | 'warning' | 'error';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
+  loading?: boolean;
+  disabled?: boolean;
+  wide?: boolean;
+  circle?: boolean;
+  square?: boolean;
+  outline?: boolean;
+  glass?: boolean;
+}
+```
+
+#### LahatCard
+```typescript
+interface LahatCardProps {
+  variant?: 'normal' | 'compact' | 'side';
+  bordered?: boolean;
+  imageFull?: boolean;
+  glass?: boolean;
+  hoverable?: boolean;
+  clickable?: boolean;
+}
+```
+
+#### LahatModal
+```typescript
+interface LahatModalProps {
+  open?: boolean;
+  backdrop?: boolean;
+  responsive?: boolean;
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+}
+```
+
+### System Integration
+
+#### Electron Main Process
+```javascript
+// main.js - System theme integration
+const { nativeTheme, ipcMain } = require('electron');
+
+// Handle theme requests from renderer
+ipcMain.handle('get-system-theme', () => {
+  return {
+    shouldUseDarkColors: nativeTheme.shouldUseDarkColors,
+    themeSource: nativeTheme.themeSource
+  };
+});
+
+// Listen for system theme changes
+nativeTheme.on('updated', () => {
+  mainWindow.webContents.send('system-theme-changed', {
+    shouldUseDarkColors: nativeTheme.shouldUseDarkColors,
+    themeSource: nativeTheme.themeSource
+  });
+});
+```
+
+#### Preload Script
+```javascript
+// preload.cjs - Expose theme API to renderer
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  getSystemTheme: () => ipcRenderer.invoke('get-system-theme'),
+  onSystemThemeChanged: (callback) => {
+    ipcRenderer.on('system-theme-changed', callback);
+  }
+});
+```
+
+## Migration Strategy
+
+### Gradual Migration Approach
+1. **Parallel Development**: Build Lahat components alongside existing system
+2. **Component-by-Component**: Migrate one component at a time
+3. **Feature Flags**: Use flags to toggle between old and new components
+4. **Rollback Plan**: Keep old components until migration is complete
+
+### Risk Mitigation
+- **Backup Strategy**: Git branches for each phase
+- **Testing**: Comprehensive testing at each phase
+- **User Feedback**: Alpha testing with early adopters
+- **Performance Monitoring**: Track performance metrics throughout
+
+## Timeline Summary
+
+| Phase | Duration | Key Deliverables |
+|-------|----------|------------------|
+| Phase 0 | Week 1 | Foundation & Planning |
+| Phase 1 | Week 2 | Core Infrastructure |
+| Phase 2 | Week 3 | DaisyUI v5 Integration |
+| Phase 3 | Week 4-5 | UI Component Migration |
+| Phase 4 | Week 6 | Advanced Features |
+| Phase 5 | Week 7 | Testing & Refinement |
+
+**Total Duration**: 7 weeks
+
+## Success Metrics
+
+### User Experience
+- [ ] Modern, professional appearance
+- [ ] Smooth animations and interactions
+- [ ] Consistent design language
+- [ ] Automatic system theme matching
+- [ ] Improved accessibility
+
+### Technical
+- [ ] Zero functionality regression
+- [ ] Maintainable component architecture
+- [ ] Future-proof design system
+- [ ] Performance maintained or improved
+- [ ] Comprehensive test coverage
+
+### Business
+- [ ] Increased user satisfaction
+- [ ] Reduced maintenance overhead
+- [ ] Faster feature development
+- [ ] Better competitive positioning
+
+## Next Steps
+
+1. **Review and Approve Plan**: Stakeholder review of this migration plan
+2. **Resource Allocation**: Assign development resources
+3. **Environment Setup**: Prepare development environment
+4. **Phase 0 Kickoff**: Begin foundation work
+
+---
+
+*This document will be updated as the migration progresses. Each phase will include detailed implementation notes and lessons learned.*

--- a/main.html
+++ b/main.html
@@ -28,6 +28,14 @@
         <div class="app-controls-header">
           <h2>Lahat <span class="tagalog-text">ᜎᜑᜆ᜔</span></h2>
           <div class="app-controls">
+            <!-- Theme toggle -->
+            <div class="theme-toggle">
+              <label class="toggle-switch">
+                <input type="checkbox" id="theme-toggle">
+                <span class="toggle-slider"></span>
+              </label>
+              <span id="theme-label">Light</span>
+            </div>
             <button id="api-settings-button" class="secondary">API Settings</button>
             <button id="create-app-button" class="primary">Create New App</button>
             <button id="import-app-button">Import App</button>

--- a/main.js
+++ b/main.js
@@ -8,7 +8,9 @@ import * as windowManager from './modules/windowManager/index.js';
 import * as apiHandlers from './modules/ipc/apiHandlers.js';
 import * as miniAppHandlers from './modules/ipc/miniAppHandlers.js';
 import * as windowHandlers from './modules/ipc/windowHandlers.js';
+import * as themeHandlers from './modules/ipc/themeHandlers.js';
 import { ErrorHandler } from './modules/utils/errorHandler.js';
+import themeManager from './modules/utils/themeManager.js';
 // Import CommonJS module correctly
 import electronUpdater from 'electron-updater';
 const { autoUpdater } = electronUpdater;
@@ -69,10 +71,14 @@ function initializeApp() {
     // Initialize window manager
     windowManager.initializeWindowManager();
     
+    // Initialize theme manager
+    themeManager.initialize();
+    
     // Register IPC handlers
     apiHandlers.registerHandlers();
     miniAppHandlers.registerHandlers();
     windowHandlers.registerHandlers();
+    themeHandlers.registerHandlers();
     
     // Initialize Claude client
     apiHandlers.initializeClaudeClient();

--- a/modules/ipc/ipcTypes.js
+++ b/modules/ipc/ipcTypes.js
@@ -44,7 +44,12 @@ export const IpcChannels = {
   GENERATION_STATUS: 'generation-status',
   GENERATION_CHUNK: 'generation-chunk',
   TITLE_DESCRIPTION_CHUNK: 'title-description-chunk',
-  LOGO_GENERATION_PROGRESS: 'logo-generation-progress'
+  LOGO_GENERATION_PROGRESS: 'logo-generation-progress',
+  
+  // Theme related
+  GET_THEME_SETTINGS: 'get-theme-settings',
+  SET_THEME: 'set-theme',
+  THEME_CHANGED: 'theme-changed'
 };
 
 /**

--- a/modules/ipc/themeHandlers.js
+++ b/modules/ipc/themeHandlers.js
@@ -1,0 +1,50 @@
+import { ipcMain } from 'electron';
+import themeManager from '../utils/themeManager.js';
+import { createSuccessResponse, createErrorResponse } from './ipcTypes.js';
+
+/**
+ * Theme Handlers Module
+ * Responsible for theme-related IPC handlers
+ */
+
+/**
+ * Handle getting theme settings
+ * @returns {Object} Current theme settings
+ */
+async function handleGetThemeSettings() {
+  try {
+    return createSuccessResponse({
+      ...themeManager.getThemeSettings()
+    });
+  } catch (error) {
+    console.error('Error getting theme settings:', error);
+    return createErrorResponse(error, 'getThemeSettings');
+  }
+}
+
+/**
+ * Handle setting theme
+ * @param {Object} event - IPC event
+ * @param {Object} params - Parameters for setting theme
+ * @returns {Promise<Object>} - Result object with success flag
+ */
+async function handleSetTheme(event, { theme }) {
+  try {
+    themeManager.setTheme(theme);
+    return createSuccessResponse();
+  } catch (error) {
+    console.error('Error setting theme:', error);
+    return createErrorResponse(error, 'setTheme');
+  }
+}
+
+/**
+ * Register theme-related IPC handlers
+ */
+export function registerHandlers() {
+  // Theme IPC handlers
+  ipcMain.handle('get-theme-settings', handleGetThemeSettings);
+  ipcMain.handle('set-theme', handleSetTheme);
+  
+  console.log('Theme handlers registered');
+}

--- a/modules/utils/themeManager.js
+++ b/modules/utils/themeManager.js
@@ -1,0 +1,180 @@
+import { nativeTheme, ipcMain, BrowserWindow } from 'electron';
+import store from '../../store.js';
+import { ErrorHandler } from './errorHandler.js';
+
+/**
+ * Theme Manager - Handles theme detection, switching, and synchronization
+ */
+class ThemeManager {
+  /**
+   * Initialize the theme manager
+   */
+  constructor() {
+    this.initialized = false;
+  }
+
+  /**
+   * Initialize the theme manager, set up listeners
+   */
+  initialize() {
+    if (this.initialized) return;
+    
+    try {
+      // Set up listener for system theme changes
+      nativeTheme.on('updated', () => {
+        this.handleSystemThemeChange();
+      });
+      
+      this.initialized = true;
+      console.log('Theme manager initialized');
+    } catch (error) {
+      ErrorHandler.logError('ThemeManager.initialize', error);
+    }
+  }
+
+  /**
+   * Handle system theme changes
+   */
+  handleSystemThemeChange() {
+    try {
+      const followSystemTheme = store.get('settings.followSystemTheme', true);
+      
+      if (followSystemTheme) {
+        const systemTheme = nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+        this.setTheme(systemTheme, false); // Set theme but don't change followSystemTheme setting
+      }
+    } catch (error) {
+      ErrorHandler.logError('ThemeManager.handleSystemThemeChange', error);
+    }
+  }
+
+  /**
+   * Get the current theme
+   * @returns {string} The current theme ('light' or 'dark')
+   */
+  getCurrentTheme() {
+    try {
+      const followSystemTheme = store.get('settings.followSystemTheme', true);
+      
+      if (followSystemTheme) {
+        return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+      } else {
+        return store.get('settings.theme', 'light');
+      }
+    } catch (error) {
+      ErrorHandler.logError('ThemeManager.getCurrentTheme', error);
+      return 'light'; // Default to light theme in case of error
+    }
+  }
+
+  /**
+   * Get the theme settings
+   * @returns {Object} The theme settings
+   */
+  getThemeSettings() {
+    try {
+      return {
+        theme: store.get('settings.theme', 'light'),
+        followSystemTheme: store.get('settings.followSystemTheme', true)
+      };
+    } catch (error) {
+      ErrorHandler.logError('ThemeManager.getThemeSettings', error);
+      return { theme: 'light', followSystemTheme: true }; // Default settings in case of error
+    }
+  }
+
+  /**
+   * Set the theme
+   * @param {string} theme - The theme to set ('light' or 'dark')
+   * @param {boolean} updateSystemThemeSetting - Whether to update the followSystemTheme setting
+   */
+  setTheme(theme, updateSystemThemeSetting = true) {
+    try {
+      // Update store
+      store.set('settings.theme', theme);
+      
+      if (updateSystemThemeSetting) {
+        store.set('settings.followSystemTheme', false);
+      }
+      
+      // Broadcast theme change to all windows
+      this.broadcastThemeChange();
+      
+      console.log(`Theme set to ${theme}, followSystemTheme: ${store.get('settings.followSystemTheme')}`);
+      
+      // Apply to renderer processes immediately without waiting for restart
+      this._applyThemeToRenderer();
+    } catch (error) {
+      ErrorHandler.logError('ThemeManager.setTheme', error);
+    }
+  }
+
+  /**
+   * Toggle system theme following
+   * @param {boolean} follow - Whether to follow the system theme
+   */
+  setFollowSystemTheme(follow) {
+    try {
+      store.set('settings.followSystemTheme', follow);
+      
+      if (follow) {
+        const systemTheme = nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+        store.set('settings.theme', systemTheme);
+      }
+      
+      // Broadcast theme change to all windows
+      this.broadcastThemeChange();
+      
+      console.log(`Follow system theme set to ${follow}`);
+    } catch (error) {
+      ErrorHandler.logError('ThemeManager.setFollowSystemTheme', error);
+    }
+  }
+
+  /**
+   * Apply the theme to renderer processes
+   * @private
+   */
+  _applyThemeToRenderer() {
+    try {
+      // For each window, inject CSS to apply the theme
+      const windows = BrowserWindow.getAllWindows();
+      
+      const currentTheme = this.getCurrentTheme();
+      
+      windows.forEach(window => {
+        // First, execute script to set data-theme attribute
+        window.webContents.executeJavaScript(`
+          document.documentElement.setAttribute('data-theme', '${currentTheme}');
+          console.log(\`Theme applied via main process: ${currentTheme}\`);
+        `).catch(err => {
+          console.error('Error applying theme via executeJavaScript:', err);
+        });
+        
+        // Then, send message for renderer to update UI controls
+        window.webContents.send('theme-changed', {
+          ...this.getThemeSettings(),
+          currentTheme
+        });
+      });
+    } catch (error) {
+      ErrorHandler.logError('ThemeManager._applyThemeToRenderer', error);
+    }
+  }
+  
+  /**
+   * Broadcast theme change to all windows
+   */
+  broadcastThemeChange() {
+    try {
+      this._applyThemeToRenderer();
+    } catch (error) {
+      ErrorHandler.logError('ThemeManager.broadcastThemeChange', error);
+    }
+  }
+}
+
+// Create singleton instance
+const themeManager = new ThemeManager();
+
+export default themeManager;

--- a/preload.cjs
+++ b/preload.cjs
@@ -240,6 +240,27 @@ contextBridge.exposeInMainWorld(
     },
     onTitleDescriptionChunk: (callback) => {
       ipcRenderer.on('title-description-chunk', (_event, chunk) => callback(chunk));
+    },
+    
+    // Theme management
+    getThemeSettings: async () => {
+      try {
+        return await ipcRenderer.invoke('get-theme-settings');
+      } catch (error) {
+        console.error('Error getting theme settings:', error);
+        throw error;
+      }
+    },
+    setTheme: async (params) => {
+      try {
+        return await ipcRenderer.invoke('set-theme', params);
+      } catch (error) {
+        console.error('Error setting theme:', error);
+        throw error;
+      }
+    },
+    onThemeChanged: (callback) => {
+      ipcRenderer.on('theme-changed', (_event, settings) => callback(settings));
     }
   }
 );

--- a/renderers/main.js
+++ b/renderers/main.js
@@ -10,6 +10,27 @@ const apiSettingsButton = document.getElementById('api-settings-button');
 const refreshAppsButton = document.getElementById('refresh-apps-button');
 const openAppDirectoryButton = document.getElementById('open-app-directory-button');
 const appList = document.getElementById('app-list');
+const noAppsMessage = document.getElementById('no-apps-message');
+
+// Theme Elements
+const themeToggle = document.getElementById('theme-toggle');
+const themeLabel = document.getElementById('theme-label');
+
+// Modal Elements
+const appDetailsModal = document.getElementById('app-details-modal');
+const modalAppName = document.getElementById('modal-app-name');
+const modalAppCreated = document.getElementById('modal-app-created');
+const modalAppVersions = document.getElementById('modal-app-versions');
+const closeModalButton = document.getElementById('close-modal-button');
+const openAppButton = document.getElementById('open-app-button');
+const updateAppButton = document.getElementById('update-app-button');
+const exportAppButton = document.getElementById('export-app-button');
+const deleteAppButton = document.getElementById('delete-app-button');
+
+// State
+let currentAppId = null;
+let currentAppFilePath = null;
+let currentAppName = null;
 
 // Initialize the app
 async function initializeApp() {
@@ -26,6 +47,9 @@ async function initializeApp() {
   
   // Set up app list event listeners
   setupAppListEventListeners();
+  
+  // Initialize theme
+  await initializeTheme();
   
   // Load existing apps
   await loadMiniApps();
@@ -212,6 +236,54 @@ window.electronAPI.onRefreshAppList(() => {
   loadMiniApps();
 });
 
+// Theme Management
+async function initializeTheme() {
+  try {
+    // Get current theme settings
+    const themeSettings = await window.electronAPI.getThemeSettings();
+    
+    // Check if we got valid settings
+    if (!themeSettings || !themeSettings.success) {
+      console.error('Failed to get theme settings:', themeSettings);
+      return;
+    }
+    
+    // Update toggle based on current theme
+    themeToggle.checked = themeSettings.theme === 'dark';
+    themeLabel.textContent = themeSettings.theme === 'dark' ? 'Dark' : 'Light';
+    
+    // Set up event listener for toggle
+    themeToggle.addEventListener('change', async () => {
+      console.log('Theme toggle changed, new state:', themeToggle.checked);
+      const newTheme = themeToggle.checked ? 'dark' : 'light';
+      themeLabel.textContent = newTheme === 'dark' ? 'Dark' : 'Light';
+      console.log('Setting theme to:', newTheme);
+      try {
+        const result = await window.electronAPI.setTheme({ theme: newTheme });
+        console.log('Theme set result:', result);
+        // Force theme change in the DOM directly
+        document.documentElement.setAttribute('data-theme', newTheme);
+      } catch (error) {
+        console.error('Error setting theme:', error);
+      }
+    });
+    
+    // Listen for theme changes from main process or other windows
+    window.electronAPI.onThemeChanged((settings) => {
+      console.log('Theme changed:', settings);
+      // Update UI when theme changes externally
+      if (settings && settings.currentTheme) {
+        themeToggle.checked = settings.currentTheme === 'dark';
+        themeLabel.textContent = settings.currentTheme === 'dark' ? 'Dark' : 'Light';
+      }
+    });
+    
+    console.log('Theme initialized:', themeSettings);
+  } catch (error) {
+    console.error('Error initializing theme:', error);
+  }
+}
+
 // Command Palette Setup
 function setupCommandPalette() {
   // Register commands
@@ -260,6 +332,14 @@ function setupCommandPalette() {
       event.preventDefault();
       commandPalette.show();
     }
+  });
+  
+  // Add toggle theme command
+  commandPalette.addCommand('toggle-theme', 'Toggle Dark/Light Theme', async () => {
+    themeToggle.checked = !themeToggle.checked;
+    const newTheme = themeToggle.checked ? 'dark' : 'light';
+    themeLabel.textContent = newTheme === 'dark' ? 'Dark' : 'Light';
+    await window.electronAPI.setTheme({ theme: newTheme });
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,11 @@
 /* Base Styles */
 :root {
+  /* Common variables */
+  --border-radius: 8px;
+  --shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  --drag-region-height: 38px; /* Height for the draggable region */
+  
+  /* Light theme colors (default) */
   --primary-color: #4285f4;
   --primary-dark: #3367d6;
   --secondary-color: #34a853;
@@ -8,9 +14,33 @@
   --light-gray: #f8f9fa;
   --medium-gray: #e0e0e0;
   --dark-gray: #5f6368;
-  --border-radius: 8px;
-  --shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  --drag-region-height: 38px; /* Height for the draggable region */
+  
+  /* Background and text colors */
+  --bg-color: #ffffff;
+  --text-color: #202124;
+  --card-bg-color: var(--light-gray);
+  --modal-bg-color: white;
+  --border-color: var(--medium-gray);
+}
+
+/* Dark theme */
+[data-theme="dark"] {
+  /* Dark theme colors */
+  --primary-color: #7baaf7;
+  --primary-dark: #5c8df1;
+  --secondary-color: #4cc669;
+  --danger-color: #f16c6c;
+  --warning-color: #fcd053;
+  --light-gray: #2c2c2c;
+  --medium-gray: #3e3e3e;
+  --dark-gray: #b0b0b0;
+  
+  /* Background and text colors */
+  --bg-color: #1e1e1e;
+  --text-color: #e8eaed;
+  --card-bg-color: #2d2d2d;
+  --modal-bg-color: #2d2d2d;
+  --border-color: #3e3e3e;
 }
 
 /* Draggable region for window dragging */
@@ -32,8 +62,8 @@
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-  background: white;
-  color: #202124;
+  background: var(--bg-color);
+  color: var(--text-color);
 }
 
 h1, h2, h3 {
@@ -121,7 +151,7 @@ textarea {
 .window {
   width: 100%;
   margin: 0;
-  background: white;
+  background: var(--bg-color);
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -143,7 +173,7 @@ textarea {
 
 /* Sections */
 .section {
-  background: white;
+  background: var(--bg-color);
   border-radius: var(--border-radius);
   padding: 20px;
   box-shadow: var(--shadow);
@@ -232,7 +262,7 @@ textarea {
 /* REMOVED: Old CSS Grid rules for #app-list - now handled by flexbox component */
 
 .app-card {
-  background: var(--light-gray);
+  background: var(--card-bg-color);
   border-radius: var(--border-radius);
   padding: 15px;
   cursor: pointer;
@@ -279,7 +309,7 @@ textarea {
 }
 
 .modal-content {
-  background: white;
+  background: var(--modal-bg-color);
   border-radius: var(--border-radius);
   width: 90%;
   max-width: 600px;
@@ -293,7 +323,7 @@ textarea {
   justify-content: space-between;
   align-items: center;
   padding: 15px 20px;
-  border-bottom: 1px solid var(--medium-gray);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .modal-header h2 {
@@ -338,4 +368,57 @@ textarea {
   display: flex;
   gap: 10px;
   margin-top: 15px;
+}
+
+/* Theme Toggle Styles */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  margin-right: 10px;
+}
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+  margin: 0 8px;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--medium-gray);
+  transition: .4s;
+  border-radius: 20px;
+}
+
+.toggle-slider:before {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  left: 2px;
+  bottom: 2px;
+  background-color: white;
+  transition: .4s;
+  border-radius: 50%;
+}
+
+input:checked + .toggle-slider {
+  background-color: var(--primary-color);
+}
+
+input:checked + .toggle-slider:before {
+  transform: translateX(20px);
 }


### PR DESCRIPTION
Addresses #6 
- Implement CSS variable-based theme system with light/dark themes
- Add simple toggle in app-controls-header for switching themes
- Create theme-related IPC handlers and renderer integration
- Connect toggle to existing ThemeManager functionality
- Fix template string issue in theme application
- Ensure themes persist between sessions
- Keep mini apps unaffected by theme changes

