### PR TITLE
Add .lahat file association and import/export functionality

### DIFF
--- a/claudeClient.js
+++ b/claudeClient.js
@@ -509,7 +509,8 @@ EXAMPLE OUTPUT:
       
       // Create a safe filename for the zip
       const safeAppName = metadata.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
-      const zipFilename = outputPath || path.join(app.getPath('downloads'), `${safeAppName}_package.zip`);
+      // If outputPath is provided, use it directly, otherwise create a default path with the app name
+      const zipFilename = outputPath || path.join(app.getPath('downloads'), `${safeAppName}.zip`);
       
       // Create a zip file
       const output = createWriteStream(zipFilename);

--- a/package.json
+++ b/package.json
@@ -55,6 +55,15 @@
   "build": {
     "appId": "com.nerdnest.lahat",
     "productName": "Lahat",
+    "fileAssociations": [
+      {
+        "ext": "lahat",
+        "name": "Lahat App",
+        "description": "Lahat Mini Application",
+        "role": "Editor",
+        "icon": "assets/icons/lahat.png"
+      }
+    ],
     "mac": {
       "category": "public.app-category.developer-tools",
       "icon": "assets/icons/lahat.png",

--- a/preload.cjs
+++ b/preload.cjs
@@ -54,6 +54,9 @@ contextBridge.exposeInMainWorld(
     onApiKeyUpdated: (callback) => {
       ipcRenderer.on('api-key-updated', () => callback());
     },
+    onRefreshAppList: (callback) => {
+      ipcRenderer.on('refresh-app-list', () => callback());
+    },
     
     // Claude API key management
     setApiKey: async (apiKey) => {

--- a/renderers/main.js
+++ b/renderers/main.js
@@ -259,6 +259,11 @@ window.electronAPI.onAppUpdated(() => {
   loadMiniApps();
 });
 
+// Listen for app list refresh requests
+window.electronAPI.onRefreshAppList(() => {
+  loadMiniApps();
+});
+
 // Command Palette Setup
 function setupCommandPalette() {
   // Register commands


### PR DESCRIPTION
This commit implements support for .lahat file extensions:
- Configure file associations in package.json to register the .lahat extension
- Update export dialog to use .lahat extension instead of .zip
- Add handler for opening .lahat files via file associations
- Implement file opening via command line arguments and open-file events
- Update mini app import/export UI to support the new file extension
- Add refresh mechanism to update app list after import
- Improve naming of exported files using the app name



When you click export here
<img width="1224" alt="image" src="https://github.com/user-attachments/assets/43183759-bdd3-41f9-a03e-a7484515f078" />

Instead of getting a generic `my-mini-app.zip` you will now get a <the-app-name>.lahat file. 
<img width="542" alt="image" src="https://github.com/user-attachments/assets/7a4bebc9-3a51-424e-b747-c6413d4e3dae" />

Then when you open that file, it automatically load into Lahat.

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/b952000a-4355-40f4-a09d-0f605dc8f353" />

When you open this file, it imports it into the Lahat app.

<img width="927" alt="image" src="https://github.com/user-attachments/assets/517e752c-c98f-4054-8ceb-2f5bbff249cd" />


**To test this locally you'll need to do npm run dist-mac and replace your copy of Lahat with this new version. This does not work with `npm run dev` since that does not properly register itself with the OS.**