### PR TITLE
make the icon logo less cheezy...

### DIFF
--- a/claudeClient.js
+++ b/claudeClient.js
@@ -181,9 +181,9 @@ EXAMPLE OUTPUT:
       }
 
       const response = await this.anthropic.messages.create({
-        model: 'claude-3-7-sonnet-20250219', // Updated to latest model
-        max_tokens: 64000, // Reduced to maximum allowed for this model
-        system: this.systemPrompt, // System prompt as top-level parameter
+        model: 'claude-opus-4-20250514',
+        max_tokens: 64000,
+        system: this.systemPrompt,
         messages,
         stream: true
       });

--- a/modules/utils/openAIClient.js
+++ b/modules/utils/openAIClient.js
@@ -69,23 +69,29 @@ class OpenAIClient {
 
   /**
    * Create an Apple-style logo prompt
-   * @param {string} appName - Name of the app
-   * @param {string} appDescription - Description of the app
-   * @returns {string} - Formatted prompt for DALL-E
+   * @param {string} appName        – Name of the app
+   * @param {string} appDescription – Short description of the app
+   * @returns {string}              – Prompt formatted for DALL-E / SDXL
    */
   createLogoPrompt(appName, appDescription) {
-    return `Create a clean, minimalist app icon in Apple's design style for "${appName}". 
-The icon should be:
-- Simple and modern with clean lines
-- Rounded square format (iOS app icon style)
-- Subtle gradients and soft shadows
-- Professional and polished appearance
-- Appropriate for: ${appDescription}
-- Use vibrant but tasteful colors
-- No text or letters in the icon
-- Style: iOS app icon, clean vector art, professional
-- Format: Square icon with rounded corners
-- High quality and crisp details`;
+  const positive = `
+Design a vibrant macOS/iOS app icon for “${appName}”.
+
+• Shape  : Rounded-square (Sonoma style)
+• Symbol : ONE centered metaphor of ${appDescription}
+• Palette: Saturated, smooth gradient
+• Finish : Flat/matte, crisp edges
+• Inspiration: Pixelmator Pro brush, Warp gradient, Slack logo
+• Output : 1024×1024 PNG, transparent background
+`.trim();
+
+  const negative = `
+### Negative prompt
+3d, bevel, extrude, drop shadow, lens flare, dull colors, washed-out,
+busy layout, text, watermark, realistic photo
+`.trim();
+
+  return `${positive}\n\n${negative}`;
   }
 
   /**


### PR DESCRIPTION
The old icons looked like this
<img width="272" alt="image" src="https://github.com/user-attachments/assets/0b74c373-36fa-47c3-aa98-99bd8bd85866" />


The new one is less cringe
<img width="131" alt="image" src="https://github.com/user-attachments/assets/8bcf00f7-7f53-4161-a524-e41452e89813" />

I also bumped up the code generation to the latest claude modle
