### PR TITLE
Read only mode

### DIFF
--- a/claudeClient.js
+++ b/claudeClient.js
@@ -16,9 +16,14 @@ const __dirname = path.dirname(__filename);
 class ClaudeClient {
   constructor(apiKey) {
     this.apiKey = apiKey;
-    this.anthropic = new Anthropic({
-      apiKey: this.apiKey || process.env.ANTHROPIC_API_KEY
-    });
+    this.readOnlyMode = !apiKey;
+    
+    // Only initialize Anthropic client if we have an API key
+    if (apiKey) {
+      this.anthropic = new Anthropic({
+        apiKey: this.apiKey || process.env.ANTHROPIC_API_KEY
+      });
+    }
     
     this.systemPrompt = `You are an expert web developer specializing in creating self-contained mini applications using HTML, CSS, and JavaScript. When given a description of an application, you will generate a complete, functional implementation that can run in an Electron window.
 
@@ -164,6 +169,11 @@ EXAMPLE OUTPUT:
   }
 
   async generateApp(prompt, conversationId = null) {
+    // Check if in read-only mode
+    if (this.readOnlyMode) {
+      throw new Error('Cannot generate app: API key not set. Please set your Claude API key in settings.');
+    }
+    
     try {
       // Initialize messages with just the user prompt
       const messages = [
@@ -196,6 +206,11 @@ EXAMPLE OUTPUT:
   }
 
   async saveGeneratedApp(appName, htmlContent, prompt, conversationId = null, logoData = null) {
+    // Check if in read-only mode
+    if (this.readOnlyMode) {
+      throw new Error('Cannot save generated app: API key not set. Please set your Claude API key in settings.');
+    }
+    
     // Create a safe folder name from the app name
     const safeAppName = appName.replace(/[^a-z0-9]/gi, '_').toLowerCase();
     const timestamp = Date.now();
@@ -377,6 +392,11 @@ EXAMPLE OUTPUT:
   }
 
   async updateGeneratedApp(conversationId, prompt, htmlContent) {
+    // Check if in read-only mode
+    if (this.readOnlyMode) {
+      throw new Error('Cannot update app: API key not set. Please set your Claude API key in settings.');
+    }
+    
     try {
       // Get all folders in the app storage directory
       const items = await fs.readdir(this.appStoragePath, { withFileTypes: true });
@@ -434,6 +454,11 @@ EXAMPLE OUTPUT:
   }
 
   async deleteGeneratedApp(conversationId) {
+    // Check if in read-only mode
+    if (this.readOnlyMode) {
+      throw new Error('Cannot delete app: API key not set. Please set your Claude API key in settings.');
+    }
+    
     try {
       // Get all folders in the app storage directory
       const items = await fs.readdir(this.appStoragePath, { withFileTypes: true });

--- a/main.js
+++ b/main.js
@@ -364,10 +364,17 @@ async function handleLahatFileOpen(filePath) {
   }
   
   try {
-    // Get the Claude client
-    const claudeClient = apiHandlers.getClaudeClient();
+    // Get the Claude client in read-only mode
+    const claudeClient = apiHandlers.getClaudeClient(true);
     if (!claudeClient) {
-      console.error('Claude client not initialized');
+      console.error('Failed to initialize Claude client in read-only mode');
+      
+      // Show error dialog to the user
+      dialog.showErrorBox(
+        'API Key Required',
+        'Cannot open .lahat file: Claude API key not set. Please set your API key in settings.'
+      );
+      
       return;
     }
     

--- a/modules/ipc/miniAppHandlers.js
+++ b/modules/ipc/miniAppHandlers.js
@@ -156,8 +156,10 @@ async function handleGenerateMiniApp(event, { prompt, appName, folderPath, conve
  */
 async function handleListMiniApps() {
   try {
-    const claudeClient = apiHandlers.getClaudeClient();
+    // Allow read-only mode for listing apps
+    const claudeClient = apiHandlers.getClaudeClient(true);
     if (!claudeClient) {
+      console.error('Failed to initialize Claude client in read-only mode');
       return { apps: [] };
     }
     
@@ -183,6 +185,15 @@ async function handleOpenMiniApp(event, { appId, filePath, name }) {
   console.log('handleOpenMiniApp called with:', { appId, filePath, name });
   
   try {
+    // Initialize Claude client in read-only mode if needed
+    if (!apiHandlers.getClaudeClient(true)) {
+      console.error('Failed to initialize Claude client in read-only mode');
+      return {
+        success: false,
+        error: 'Failed to initialize app environment. Please check your settings.'
+      };
+    }
+    
     const result = await miniAppManager.openMiniApp(appId, filePath, name);
     return result;
   } catch (error) {
@@ -327,11 +338,13 @@ async function handleDeleteMiniApp(event, { appId }) {
  */
 async function handleExportMiniApp(event, { appId, filePath }) {
   try {
-    const claudeClient = apiHandlers.getClaudeClient();
+    // Allow read-only mode for exporting apps
+    const claudeClient = apiHandlers.getClaudeClient(true);
     if (!claudeClient) {
+      console.error('Failed to initialize Claude client in read-only mode');
       return {
         success: false,
-        error: 'Claude API key not set. Please set your API key in settings.'
+        error: 'Failed to initialize app environment. Please check your settings.'
       };
     }
     
@@ -409,11 +422,13 @@ async function handleExportMiniApp(event, { appId, filePath }) {
  */
 async function handleImportMiniApp(event) {
   try {
-    const claudeClient = apiHandlers.getClaudeClient();
+    // Allow read-only mode for importing apps
+    const claudeClient = apiHandlers.getClaudeClient(true);
     if (!claudeClient) {
+      console.error('Failed to initialize Claude client in read-only mode');
       return {
         success: false,
-        error: 'Claude API key not set. Please set your API key in settings.'
+        error: 'Failed to initialize app environment. Please check your settings.'
       };
     }
     


### PR DESCRIPTION
I was halfway into this when I realized I hadn't switched over to sonnet 4 from sonnet 3.7. It works, but does introduce some ideas that we may not want if we want to be more generic with our API clients.


1. __Modified ClaudeClient class__:

   - Added support for a read-only mode when initialized without an API key
   - Maintained full functionality for file operations that don't require API access

2. __Updated API handlers__:

   - Modified `initializeClaudeClient` and `getClaudeClient` to support read-only mode
   - Added parameter to allow read-only initialization when appropriate

3. __Updated mini-app handlers__:

   - Modified handlers for listing, opening, importing, and exporting mini-apps to work in read-only mode
   - Added proper error handling with user-friendly messages

4. __Fixed .lahat file handling__:

   - Updated `handleLahatFileOpen` to use read-only mode
   - Added proper error dialog when API key is missing