### PR TITLE
drive auto code review from github app not legacy action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   claude-review:
+    # Skip draft PRs to avoid unnecessary runs and save GitHub Actions minutes
+    if: github.event.pull_request.draft == false
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -19,10 +22,12 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
     
     runs-on: ubuntu-latest
+    timeout-minutes: 30  # Prevent runaway jobs from consuming excessive resources
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
+      # Write permissions required for GitHub App to post review comments
+      pull-requests: write  # Needed to create PR review comments
+      issues: write         # Needed for issue comments and reactions
       id-token: write
     
     steps:


### PR DESCRIPTION
Claude is unable to run review on its own commits as mentioned in [Anthropic's FAQ](https://docs.anthropic.com/en/docs/claude-code/github-actions#ci-not-running-on-claude%E2%80%99s-commits). 

Reading the directions more closely shows these as the recommended permissions (for a custom github app).  Making the job match the recommended permissions so the in scope GITHUB_TOKEN inherits as such.

```
Set the required permissions:

    Repository permissions:
        Contents: Read & Write
        Issues: Read & Write
        Pull requests: Read & Write
```