### PR TITLE
provide the built-in GH_TOKEN to the workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,7 +41,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
           


### PR DESCRIPTION
The OIDC failure is happening because:
  1. The GitHub Actions workflow is trying to authenticate as the Claude GitHub App
  2. The app token exchange is failing with "User does not have write access"
  3. This suggests either the app permissions or the workflow's id-token: write permission isn't working correctly

  The real issue is likely one of these:
  - The workflow's OIDC token isn't being accepted by the Claude app's authentication service
  - There's a mismatch between the workflow permissions and what the app expects
  - The app's OIDC configuration doesn't recognize this repository context

  We should add github_token: ${{ secrets.GITHUB_TOKEN }} to bypass the OIDC authentication entirely and use GitHub's built-in token instead.